### PR TITLE
Synchronize Bundle ID and Certificate

### DIFF
--- a/AR-Poker-Hand-Identifier.xcodeproj/project.pbxproj
+++ b/AR-Poker-Hand-Identifier.xcodeproj/project.pbxproj
@@ -436,14 +436,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = K78326Z837;
 				INFOPLIST_FILE = "AR-Poker-Hand-Identifier/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier";
+				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier-test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -453,14 +456,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = K78326Z837;
 				INFOPLIST_FILE = "AR-Poker-Hand-Identifier/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier";
+				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier-test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/AR-Poker-Hand-Identifier.xcodeproj/project.pbxproj
+++ b/AR-Poker-Hand-Identifier.xcodeproj/project.pbxproj
@@ -438,13 +438,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = K78326Z837;
+				DEVELOPMENT_TEAM = 8ATJ2KR693;
 				INFOPLIST_FILE = "AR-Poker-Hand-Identifier/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier-test";
+				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;
@@ -458,13 +458,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = K78326Z837;
+				DEVELOPMENT_TEAM = 8ATJ2KR693;
 				INFOPLIST_FILE = "AR-Poker-Hand-Identifier/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier-test";
+				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;

--- a/AR-Poker-Hand-Identifier.xcodeproj/project.pbxproj
+++ b/AR-Poker-Hand-Identifier.xcodeproj/project.pbxproj
@@ -438,13 +438,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8ATJ2KR693;
+				DEVELOPMENT_TEAM = K78326Z837;
 				INFOPLIST_FILE = "AR-Poker-Hand-Identifier/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier";
+				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.CS499.AR-Poker-Hand-Identifier";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;
@@ -458,13 +458,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8ATJ2KR693;
+				DEVELOPMENT_TEAM = K78326Z837;
 				INFOPLIST_FILE = "AR-Poker-Hand-Identifier/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.AR-Poker-Hand-Identifier";
+				PRODUCT_BUNDLE_IDENTIFIER = "SDLC.CS499.AR-Poker-Hand-Identifier";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;


### PR DESCRIPTION
Made a group apple id account so that we can all log in and use one license to deploy on our phones. This should set the app settings so the bundle ID is SDLC.CS499.AR-Poker-Hand-Identifier and the certificate should be under my name.